### PR TITLE
Fix parseApplyPatch to handle trailing newline

### DIFF
--- a/codex-cli/src/parse-apply-patch.ts
+++ b/codex-cli/src/parse-apply-patch.ts
@@ -35,17 +35,18 @@ export const HUNK_ADD_LINE_PREFIX = "+";
  * @returns null when the patch is invalid
  */
 export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
-  if (!patch.startsWith(PATCH_PREFIX)) {
+  const trimmed = patch.trimEnd();
+  if (!trimmed.startsWith(PATCH_PREFIX)) {
     // Patch must begin with '*** Begin Patch'
     return null;
-  } else if (!patch.endsWith(PATCH_SUFFIX)) {
+  } else if (!trimmed.endsWith(PATCH_SUFFIX)) {
     // Patch must end with '*** End Patch'
     return null;
   }
 
-  const patchBody = patch.slice(
+  const patchBody = trimmed.slice(
     PATCH_PREFIX.length,
-    patch.length - PATCH_SUFFIX.length,
+    trimmed.length - PATCH_SUFFIX.length,
   );
 
   const lines = patchBody.split("\n");

--- a/codex-cli/src/utils/agent/parse-apply-patch.ts
+++ b/codex-cli/src/utils/agent/parse-apply-patch.ts
@@ -34,17 +34,18 @@ const HUNK_ADD_LINE_PREFIX = "+";
  * @returns null when the patch is invalid
  */
 export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
-  if (!patch.startsWith(PATCH_PREFIX)) {
+  const trimmed = patch.trimEnd();
+  if (!trimmed.startsWith(PATCH_PREFIX)) {
     // Patch must begin with '*** Begin Patch'
     return null;
-  } else if (!patch.endsWith(PATCH_SUFFIX)) {
+  } else if (!trimmed.endsWith(PATCH_SUFFIX)) {
     // Patch must end with '*** End Patch'
     return null;
   }
 
-  const patchBody = patch.slice(
+  const patchBody = trimmed.slice(
     PATCH_PREFIX.length,
-    patch.length - PATCH_SUFFIX.length,
+    trimmed.length - PATCH_SUFFIX.length,
   );
 
   const lines = patchBody.split("\n");

--- a/codex-cli/tests/parse-apply-patch.test.ts
+++ b/codex-cli/tests/parse-apply-patch.test.ts
@@ -38,6 +38,19 @@ describe("parseApplyPatch", () => {
     ]);
   });
 
+  test("accepts trailing newline after patch", () => {
+    const patchWithNewline =
+      `*** Begin Patch\n*** Add File: foo.txt\n+bar\n*** End Patch\n`;
+    const ops = mustParse(patchWithNewline);
+    expect(ops).toEqual([
+      {
+        type: "create",
+        path: "foo.txt",
+        content: "bar",
+      },
+    ]);
+  });
+
   test("returns null for an invalid patch (missing prefix)", () => {
     const invalid = `*** Add File: foo.txt\n+bar\n*** End Patch`;
     expect(parseApplyPatch(invalid)).toBeNull();


### PR DESCRIPTION
## Summary
- handle trailing newline characters in `parseApplyPatch`
- update utility copy of parser
- cover newline case in unit tests

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test --workspace -- --test-threads=1` *(fails: failed to get `ansi-to-tui` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_b_6879a3cefe3c8330bfedfcf7d3857f20